### PR TITLE
Support for Ruby 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ workflows:
               ruby-version:
                 - "3.4.2"
                 - "3.3.7"
+                - "3.2.7"
       - rubocop
       - release:
           filters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.2
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
     drb (2.2.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
+    ffi (1.17.1)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
@@ -133,6 +134,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  ruby
   x86_64-darwin
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    voyageai (1.7.0)
+    voyageai (1.8.0)
       http
       zeitwerk
 

--- a/lib/voyageai/version.rb
+++ b/lib/voyageai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module VoyageAI
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end

--- a/voyageai.gemspec
+++ b/voyageai.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A library for generating embeddings with https://voyageai.com"
   spec.homepage = "https://github.com/ksylvest/voyageai"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.3.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
# Description
The current implementation of this gem requires Ruby 3.3 or later. I wanted to test VoyageAI with our code base that's running on Ruby 3.2. While we could update the entire code base to Ruby 3.3, I'd rather have a less strict requirement on this gem.

Ruby 3.2 is still under active support, with an [expected EOL of 2026-03-31](https://www.ruby-lang.org/en/downloads/branches/).

# Work Done
- Changed the version of Ruby required in the Gemspec to 3.2
- Changed Rubocop to match

I don't know why the `Gemfile.lock` changed, but generally I think the gems don't check in `Gemfile.lock` anyway

# Testing
- I verified that the test suite runs
- I wired this up to our system and ran embeddings for ~500 contexts