### PR TITLE
Support Voyage 3.5 and 3.5-lite

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    voyageai (1.8.0)
+    voyageai (1.9.0)
       http
       zeitwerk
 

--- a/lib/voyageai/model.rb
+++ b/lib/voyageai/model.rb
@@ -2,6 +2,8 @@
 
 module VoyageAI
   module Model
+    VOYAGE_3_5 = "voyage-3.5"
+    VOYAGE_3_5_LITE = "voyage-3.5-lite"
     VOYAGE_3 = "voyage-3"
     VOYAGE_3_LARGE = "voyage-3-large"
     VOYAGE_3_LITE = "voyage-3-lite"
@@ -13,8 +15,8 @@ module VoyageAI
     RERANK_2 = "rerank-2"
     RERANK_2_LITE = "rerank-2-lite"
 
-    VOYAGE = VOYAGE_3
-    VOYAGE_LITE = VOYAGE_3_LITE
+    VOYAGE = VOYAGE_3_5
+    VOYAGE_LITE = VOYAGE_3_5_LITE
     VOYAGE_FINANCE = VOYAGE_FINANCE_2
     VOYAGE_MULTILINGUAL = VOYAGE_MULTILINGUAL_2
     VOYAGE_LAW = VOYAGE_LAW_2

--- a/lib/voyageai/version.rb
+++ b/lib/voyageai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module VoyageAI
-  VERSION = "1.8.0"
+  VERSION = "1.9.0"
 end

--- a/spec/voyageai/embed_spec.rb
+++ b/spec/voyageai/embed_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe VoyageAI::Embed do
     let(:embed) { build(:embed, embeddings: []) }
 
     it "returns a string" do
-      expect(inspect).to eql '#<VoyageAI::Embed model="voyage-3" embeddings=[] usage=#<VoyageAI::Usage total_tokens=0>>'
+      expect(inspect).to eql(%(#<VoyageAI::Embed model="voyage-3.5" embeddings=[] usage=#{embed.usage.inspect}>))
     end
   end
 


### PR DESCRIPTION
## Context
This defines constants for the `VoyageAI::Model::VOYAGE_3_5` and `VoyageAI::Model::VOYAGE_3_5_LITE` constants. It also remaps:

`VoyageAI::Model::VOYAGE` => `VoyageAI::Model::VOYAGE_3_5`
`VoyageAI::Model::VOYAGE_LITE` => `VoyageAI::Model::VOYAGE_3_5_LITE`

This changes the default model (if not is specified) from `VoyageAI::Model::VOYAGE_3` to `VoyageAI::Model::VOYAGE_3_5`.