### PR TITLE
Fix typo in README: change 'emed' to 'embed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ input = 'A quick brown fox jumps over the lazy dog.'
 
 voyageai = VoyageAI::Client.new(api_key: 'pa-...') # or configure ENV['VOYAGEAI_API_KEY']
 
-embed = voyageai.emed(input)
+embed = voyageai.embed(input)
 embed.model # "..."
 embed.usage # "#<VoyageAI::Usage total_tokens=...>"
 embed.embedding # [0.0, ...]


### PR DESCRIPTION
## Summary
- Fixed typo in README.md line 30: changed `voyageai.emed(input)` to `voyageai.embed(input)`

## Test plan
- [x] Verified the typo exists in the original README
- [x] Applied the fix and confirmed it matches the expected method name
- [x] No functional code changes, only documentation correction

🤖 Generated with [Claude Code](https://claude.ai/code)